### PR TITLE
Fix crash bug with duplicate inputs within a transaction

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1174,7 +1174,7 @@ CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
       {
 	return CAmount(105000 * COIN);
       }
-    
+
     CAmount nSubsidy = 50 * COIN;
     // Subsidy is cut in half every 210,000 blocks which will occur approximately every 4 years.
     nSubsidy >>= halvings;
@@ -2885,7 +2885,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
 
     // Check transactions
     for (const auto& tx : block.vtx)
-        if (!CheckTransaction(*tx, state, false))
+        if (!CheckTransaction(*tx, state, true))
             return state.Invalid(false, state.GetRejectCode(), state.GetRejectReason(),
                                  strprintf("Transaction check failed (tx hash %s) %s", tx->GetHash().ToString(), state.GetDebugMessage()));
 


### PR DESCRIPTION
- Refers to bug in Bitcoin Core.
- https://github.com/bitcoin/bitcoin/commit/d926a87fde80b64024b2d94260c53aab20ccb259